### PR TITLE
Make it easier for users to select the correct org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog: dsd-upsun
 ===
 
+### 1.2.1
+
+#### External changes
+
+- The dialog for selecting which organization shows the org name, ID, and whether it's a Flex or Fixed org. This makes it much easier to select the appropriate org for users who have multiple orgs. New Upsun accounts have a default Flex plan, so all new users trying to make a Fixed deployment will likely have at least two orgs.
+
+#### Internal changes
+
+- The util function `get_org_names()` is now `get_org_ids_names()`.
+
 ### 1.2.0
 
 The version is jumping to 1.2.0, because the dsd-platformsh plugin that this is based on already had a 1.1.0 release.

--- a/dsd_upsun/platform_deployer.py
+++ b/dsd_upsun/platform_deployer.py
@@ -352,8 +352,11 @@ class PlatformDeployer:
         This is needed for creating a project using automate_all.
         Confirm that it's okay to use this org.
 
+        Note: In the csv output, Upsun refers to the alphanumeric ID as a Name,
+        and the user-provided name as a Label. This gets confusing. :/
+
         Returns:
-            str: org name
+            str: org name (id)
             None: if not using automate-all
         Raises:
             DSDCommandError:
@@ -368,7 +371,8 @@ class PlatformDeployer:
         output_str = output_obj.stdout.decode()
         plugin_utils.log_info(output_str)
 
-        org_names = upsun_utils.get_org_names(output_str)
+        org_ids, org_names = upsun_utils.get_org_ids_names(output_str)
+
         if not org_names:
             raise DSDCommandError(upsun_msgs.org_not_found)
 
@@ -376,13 +380,14 @@ class PlatformDeployer:
             # Get permission to use this org.
             org_name = org_names[0]
             if self._confirm_use_org(org_name):
-                return org_name
+                # Return the corresponding ID, not the name.
+                return org_ids[0]
 
-        # Show all orgs, ask user to make selection.
-        prompt = "\n*** Found multiple orgs on Upsun. ***"
+        # Show all org names, ask user to make selection.
+        prompt = "\n*** Found multiple organizations on Upsun. ***\n"
         for index, name in enumerate(org_names):
             prompt += f"\n  {index}: {name}"
-        prompt += "\nWhich org would you like to use? "
+        prompt += "\n\nWhich organization would you like to use? "
 
         valid_choices = [i for i in range(len(org_names))]
 
@@ -398,7 +403,8 @@ class PlatformDeployer:
             confirm_prompt += " Is that correct?"
             confirmed = plugin_utils.get_confirmation(confirm_prompt)
 
-            return selected_org
+            # Return corresponding ID, not the name.
+            return org_ids[selection]
 
     def _confirm_use_org(self, org_name):
         """Confirm that it's okay to use the org that was found.

--- a/dsd_upsun/utils.py
+++ b/dsd_upsun/utils.py
@@ -20,8 +20,8 @@ def get_project_name(output_str):
     return project_name
 
 
-def get_org_names(output_str):
-    """Get org names from output of `upsun organization:list --yes --format csv`.
+def get_org_ids_names(output_str):
+    """Get org ids and names from output of `upsun organization:list --yes --format csv`.
 
     Sample input:
         Name,Label,Owner email
@@ -29,20 +29,24 @@ def get_org_names(output_str):
         <org-name-2>,<org-label-2>,<org-owner-2@example.com>
 
     Returns:
-        list: [str]
+        tuple: list, list
         None: If user has no organizations.
     """
     if "No organizations found." in output_str:
         return None
 
     lines = output_str.split("\n")[1:]
-    # Build names like this: "<org-id> <org-label> (<flexible|fixed>)"
+
+    org_ids = [line.split(",")[0] for line in lines if line]
+
+    # Build descriptive names like this: "<org-id> <org-label> (<flexible|fixed>)"
     org_names = [
-        f"{line.split(",")[0]}\t{line.split(",")[1]}\t({line.split(",")[2]})"
+        f"{line.split(",")[0]} {line.split(",")[1]} ({line.split(",")[2]})"
         for line in lines
         if line
     ]
-    return org_names
+
+    return org_ids, org_names
 
 
 def fix_git_exclude_bug():

--- a/dsd_upsun/utils.py
+++ b/dsd_upsun/utils.py
@@ -36,7 +36,13 @@ def get_org_names(output_str):
         return None
 
     lines = output_str.split("\n")[1:]
-    return [line.split(",")[0] for line in lines if line]
+    # Build names like this: "<org-id> <org-label> (<flexible|fixed>)"
+    org_names = [
+        f"{line.split(",")[0]}\t{line.split(",")[1]}\t({line.split(",")[2]})"
+        for line in lines
+        if line
+    ]
+    return org_names
 
 
 def fix_git_exclude_bug():


### PR DESCRIPTION
When selecting which org to use in automate-all runs, show a descriptive name for each org including ID, label, and plan type (flex or fixed).